### PR TITLE
use Python 3.8 for coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,4 @@ jobs:
           coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         # coverage is only created in the py39 environment
         # --service=github is a workaround for bug
         # https://github.com/coveralls-clients/coveralls-python/issues/251
-        if: "matrix.python-version == '3.9'"
+        if: "matrix.python-version == '3.8'"
         run: |
           pip install coveralls
           coveralls --service=github

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,8 @@ commands = pre-commit run --all-files
 python =
     3.6: py36
     3.7: py37
-    3.8: py38
-    3.9: py39, pre-commit, mypy, coverage
+    3.8: py38, coverage
+    3.9: py39, pre-commit, mypy
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Reporting to coveralls is sometimes broken and seemingly nobody really
knows why.

One suggested workaround is to run coveralls on 3.8.

Let's try.